### PR TITLE
Fix entry trimming in command handler

### DIFF
--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -101,7 +101,7 @@ define(['d3'], function () {
         },
 
         command: function (entry) {
-            if (entry.trim === '') {
+            if (entry.trim() === '') {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- fix call to `trim` within the command handler so empty inputs are ignored

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684857260dc483248d2f05ededc1b3ae